### PR TITLE
Updated docs to reflect Unity 5.5 supprt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Event wifi can be spotty, so you'll be best off if you download all of the neces
 You will need:
 * Visual Studio 2015 with Update 3
 * The Windows 10 SDK
-* Unity HoloLens Technical Preview
+* Unity 5.5 or later
 
 Optionally, you will need:
 * The HoloLens Emulator to test your applications on (Requires Win 10)
@@ -34,7 +34,7 @@ You should also bookmark the [HoloLens Developer main site](https://www.microsof
 When it's time to program your application, the best way to get started with your app will probably be a clean Unity project. You'll also likely want to grab the HoloTookKit-Unity package from GitHub to use in your project. 
 
 ### Create a new Project in Unity
-1. Double check that you have the [latest HoloLens Technical Preview from Unity](https://unity3d.com/partners/microsoft/hololens#download).
+1. Double check that you have Unity 5.5 or greater.
 
 2. Download the [HoloToolKit-Unity](https://github.com/Microsoft/HoloToolkit-Unity/) project as a zip folder from GitHub. 
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -5,7 +5,7 @@ While hackathon mentors are awesome++, there are a few things that you can do to
 Before you track down a mentor for help, go through the following checklist to make sure that you're not hitting some of the most basic bugs:
 
 1. Check the version of Visual Studio 2015 you're running and make sure that Update 3 is installed.
-2. Make sure that you have an up to date HoloLens Technical Preview Unity installation. You can check that you have a HoloLens build by going to Programs & Features > Unity and making sure that the version you are using has -HTP at the end of the name. Example: Unity HoloLens 5.4.0f3-HTP
+2. Make sure that you are using Unity 5.5 or later
 3. Confirm that you have the Windows 10 SDK installed. You can check this by opening up Visual Studio, clicking 'New Project', and seeing if there is an option for Windows Universal under Visual C# (you don't have to actually create the project, just see if the option is there)
 4. Enable developer mode on your local machine
 5. See if the problem reproduces when you try a different deployment option (e.g. if you can't deploy over USB, try Wi-Fi, and vice-versa)


### PR DESCRIPTION
No longer need a technical preview of Unity to develop for HoloLens. Changed guide to reflect Unity 5.5 support